### PR TITLE
Use a IProxyListener instead of a IHttpListener, fixes #5

### DIFF
--- a/burp/src/burp/BurpExtender.kt
+++ b/burp/src/burp/BurpExtender.kt
@@ -1,8 +1,9 @@
 package  burp
 
 import java.io.PrintWriter
+import java.util.*
 
-class BurpExtender : IBurpExtender, IHttpListener, IExtensionStateListener {
+class BurpExtender : IBurpExtender, IProxyListener, IExtensionStateListener {
 
     private lateinit var callbacks: IBurpExtenderCallbacks
     private lateinit var helpers: IExtensionHelpers
@@ -16,32 +17,34 @@ class BurpExtender : IBurpExtender, IHttpListener, IExtensionStateListener {
         this.stderr = PrintWriter(callbacks.stderr, true)
 
         callbacks.setExtensionName("PwnFox")
-        callbacks.registerHttpListener(this)
         callbacks.registerExtensionStateListener(this)
+        callbacks.registerProxyListener(this)
         stdout.println("PwnFox Loaded")
     }
 
 
-    override fun processHttpMessage(toolFlag: Int, messageIsRequest: Boolean, messageInfo: IHttpRequestResponse) {
-        if (!messageIsRequest) return
-        val requestInfo = helpers.analyzeRequest(messageInfo)
-        val body = messageInfo.request.drop(requestInfo.bodyOffset).toByteArray()
-        val (pwnFoxHeaders, cleanHeaders) = requestInfo.headers.partition {
-            it.toLowerCase().startsWith("x-pwnfox-")
-        }
-
-        pwnFoxHeaders.forEach() {
-            if (it.toLowerCase().startsWith(("x-pwnfox-color:"))) {
-                val (_, color) = it.split(":", limit = 2)
-                messageInfo.highlight = color.trim()
-            }
-        }
-
-        messageInfo.request =
-            helpers.buildHttpMessage(cleanHeaders, body)
-
+    override fun extensionUnloaded() {
     }
 
-    override fun extensionUnloaded() {
+    override fun processProxyMessage(messageIsRequest: Boolean, message: IInterceptedProxyMessage?) {
+        if (!messageIsRequest) return
+
+        val messageInfo = message?.messageInfo
+        if (messageInfo != null) {
+
+            val requestInfo = helpers.analyzeRequest(messageInfo)
+            val body = messageInfo.request.drop(requestInfo.bodyOffset).toByteArray()
+            val (pwnFoxHeaders, cleanHeaders) = requestInfo.headers.partition {
+                it.lowercase(Locale.getDefault()).startsWith("x-pwnfox-")
+            }
+
+            pwnFoxHeaders.forEach() {
+                if (it.lowercase(Locale.getDefault()).startsWith(("x-pwnfox-color:"))) {
+                    val (_, color) = it.split(":", limit = 2)
+                    messageInfo.highlight = color.trim()
+                }
+            }
+            messageInfo.request = helpers.buildHttpMessage(cleanHeaders, body)
+        }
     }
 }


### PR DESCRIPTION
Hello,

Is there any good reason to use a IHttpListener instead of a IProxyListener? Don't we want to only modify messages coming from the browser anyway?

This is an attempt to fix #5 by implementing a IProxyListener instead of a IHttpListener.

An alternative would be to still use IHttpListener but use the toolFlag value to decide if we want to process the message or not. The "advantage" of using the IProxyListener is that it allows the users to see both the original and the edited request in the proxy tab.