### PR TITLE
stop proxy request if [ X-Do-Not-Proxy: on ] Header exist in request

### DIFF
--- a/firefox/src/features.js
+++ b/firefox/src/features.js
@@ -30,7 +30,7 @@ class Feature {
 
 function proxify(config, onlyContainers) {
     return async function (e) {
-        if (onlyContainers && e.cookieStoreId == 'firefox-default')
+        if ((onlyContainers && e.cookieStoreId == 'firefox-default') || e.requestHeaders.some(header => header.name === "X-Do-Not-Proxy" && header.value === "on"))
             return { type: "direct" };
         const host = await config.get("burpProxyHost")
         const port = await config.get("burpProxyPort")

--- a/firefox/src/features.js
+++ b/firefox/src/features.js
@@ -54,7 +54,7 @@ class UseBurpProxyAll extends Feature {
         super.start()
         if (!await this.config.get("enabled")) return
 
-        browser.proxy.onRequest.addListener(this.proxy, { urls: ["<all_urls>"] })
+        browser.proxy.onRequest.addListener(this.proxy, { urls: ["<all_urls>"] },["requestHeaders"])
 
     }
 
@@ -75,7 +75,7 @@ class UseBurpProxyContainers extends Feature {
         super.start()
         if (!await this.config.get("enabled")) return
 
-        browser.proxy.onRequest.addListener(this.proxy, { urls: ["<all_urls>"] })
+        browser.proxy.onRequest.addListener(this.proxy, { urls: ["<all_urls>"] },["requestHeaders"])
     }
 
     stop() {


### PR DESCRIPTION
Hi

Sometimes I need to send some requests through the browser and I don't want to proxy those requests, so I have to stop them to go to a burp scan for example.

So a header can help here. I made some small changes to the proxy
onRequest listener